### PR TITLE
Remove Joomla residue and adopt HTML5 doctype

### DIFF
--- a/s3/bv-thomson-revised-2.html
+++ b/s3/bv-thomson-revised-2.html
@@ -1,65 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>BV Thomson Chapter 2 rev - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/email-page.html
+++ b/s3/email-page.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Mirrored from tomleonard.co.uk/email-page.html by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 29 Jan 2019 22:58:47 GMT -->
@@ -8,59 +8,16 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>literaryestate@tomleonard.co.uk - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/index.html
+++ b/s3/index.html
@@ -1,51 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 <head>
-    <script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base  />
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 	<meta name="author" content="tom" />
 	<meta name="description" content="Tom Leonard - Scottish Writer. Read and hear his work" />
-	<meta name="generator" content="Joomla! - Open Source Content Management" />
 	<title>Homepage   - tomleonard.co.uk</title>
-	<link href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css" rel="stylesheet" type="text/css" />
-	<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-	<script src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js" type="text/javascript"></script>
-	<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]--> 
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
-
-
-
-
-<link href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico" rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript" src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
+	<link href="index900f.css" rel="stylesheet" type="text/css" />
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal.html
+++ b/s3/journal.html
@@ -1,65 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>Journal 2014 - 2009 - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/my-name-is-tom.html
+++ b/s3/my-name-is-tom.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Mirrored from tomleonard.co.uk/my-name-is-tom.html by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 29 Jan 2019 22:58:41 GMT -->
@@ -8,60 +8,17 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>My Name is Tom - performance score with soundtrack -
 	tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose.html
+++ b/s3/online-poetry-and-prose.html
@@ -1,64 +1,21 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>six glasgow poems - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/places-of-the-mind-revised.html
+++ b/s3/places-of-the-mind-revised.html
@@ -1,65 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>BV Thomson Chapter 1 rev - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters.html
+++ b/s3/selected-letters.html
@@ -1,65 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>Selected Letters - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/songs-by-bertolt-brecht.html
+++ b/s3/songs-by-bertolt-brecht.html
@@ -1,66 +1,23 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Brecht, Tom Leonard, Mother Courage and her Children, Scottish Literature" />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Brecht, Mother Courage and her Children songs translated by Tom Leonard" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>7 Songs from Brecht's Mother Courage and Her Children -
 	tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/videos-slide-poems.html
+++ b/s3/videos-slide-poems.html
@@ -1,61 +1,18 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="author" content="Tom Leonard" />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>kinetic poems - tomleonard.co.uk</title>
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
-	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/web-links.html
+++ b/s3/web-links.html
@@ -1,63 +1,25 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
+<html lang="en-gb">
 
 
 <!-- Added by HTTrack -->
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
-<base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="keywords"
 	content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
 <meta name="description"
 	content="Tom Leonard - Scottish Writer. Read and hear his work" />
-<meta name="generator"
-	content="Joomla! - Open Source Content Management" />
 <title>Links - tomleonard.co.uk</title>
 <link href="web-linksdcab.feed?type=rss" rel="alternate"
 	type="application/rss+xml" title="RSS 2.0" />
 <link href="web-linksb550.html?type=atom" rel="alternate"
 	type="application/atom+xml" title="Atom 1.0" />
 <link
-	href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css"
+	href="index900f.css"
 	rel="stylesheet" type="text/css" />
-<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
-<script
-	src="index96f4.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_36cba.js"
-	type="text/javascript"></script>
-
-<!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-<!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
-
-
-
-
-<link
-	href="http://tomleonard.co.uk/plugins/system/jat3/jat3/base-themes/default/images/favicon.ico"
-	rel="shortcut icon" type="image/x-icon" />
-
-
-<!--[if IE 7.0]>
-<style>
-.clearfix { display: inline-block; } /* IE7xhtml*/
-</style>
-<![endif]-->
-
-<script language="javascript" type="text/javascript">
-var rightCollapseDefault='show';
-var excludeModules='38';
-</script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {


### PR DESCRIPTION
## Summary
- Switch all top-level `s3` HTML pages to `<!DOCTYPE html>` and `<html lang="en-gb">`.
- Strip Joomla generator metadata, scripts, and dynamic query strings for a cleaner head section.
- Simplify CSS references to static files.

## Testing
- `for f in s3/*.html; do if [ "$f" = "s3/googlefbed4af40438383b.html" ]; then continue; fi; git show HEAD:"$f" | w3m -T text/html -dump - > /tmp/orig.txt; w3m -dump "$f" > /tmp/new.txt; diff -u /tmp/orig.txt /tmp/new.txt > /tmp/diff.txt && echo "No rendering differences for $f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689ae9834014832786f3dd7c67e04333