### PR TITLE
chore: remove legacy script references

### DIFF
--- a/s3/bv-thomson-revised-2.html
+++ b/s3/bv-thomson-revised-2.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/email-page.html
+++ b/s3/email-page.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/index.html
+++ b/s3/index.html
@@ -3,12 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
 
 <head>
-    <script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
+    
 <base  />
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
@@ -19,12 +14,7 @@ var isRTL = false;
 	<link href="index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css" rel="stylesheet" type="text/css" />
 	<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
 	<script src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js" type="text/javascript"></script>
-	<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
+	
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]--> 
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
 <!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
@@ -45,7 +35,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript" src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal.html
+++ b/s3/journal.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/aug.html
+++ b/s3/journal/aug.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/blog-jan.html
+++ b/s3/journal/blog-jan.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/blog-march.html
+++ b/s3/journal/blog-march.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/blog-may.html
+++ b/s3/journal/blog-may.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/december-2010-november.html
+++ b/s3/journal/december-2010-november.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/feb2014dec2013.html
+++ b/s3/journal/feb2014dec2013.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/jan-2012.html
+++ b/s3/journal/jan-2012.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/jan-2013-dec-2012.html
+++ b/s3/journal/jan-2013-dec-2012.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/janmar.html
+++ b/s3/journal/janmar.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/juljun2012.html
+++ b/s3/journal/juljun2012.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/juneapr.html
+++ b/s3/journal/juneapr.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/junmarch2009.html
+++ b/s3/journal/junmarch2009.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/marfeb2012.html
+++ b/s3/journal/marfeb2012.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/mayapril2012-sp-1408760732.html
+++ b/s3/journal/mayapril2012-sp-1408760732.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/mayapril2012-sp-1750726161.html
+++ b/s3/journal/mayapril2012-sp-1750726161.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/mayfeb-2013.html
+++ b/s3/journal/mayfeb-2013.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/novoct.html
+++ b/s3/journal/novoct.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/novoct2013.html
+++ b/s3/journal/novoct2013.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/octjul2009.html
+++ b/s3/journal/octjul2009.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/sep-dec.html
+++ b/s3/journal/sep-dec.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/sepaug2012.html
+++ b/s3/journal/sepaug2012.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/sepjuly2011.html
+++ b/s3/journal/sepjuly2011.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/sepjun2013.html
+++ b/s3/journal/sepjun2013.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/september-march-2014.html
+++ b/s3/journal/september-march-2014.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/journal/september-october.html
+++ b/s3/journal/september-october.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/my-name-is-tom.html
+++ b/s3/my-name-is-tom.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -32,11 +27,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -60,8 +50,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose.html
+++ b/s3/online-poetry-and-prose.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -29,11 +24,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -57,8 +47,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/100-differences-between-poetry-and-prose.html
+++ b/s3/online-poetry-and-prose/100-differences-between-poetry-and-prose.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/a-humanist.html
+++ b/s3/online-poetry-and-prose/a-humanist.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/epithalamium.html
+++ b/s3/online-poetry-and-prose/epithalamium.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/liasoncoordinator.html
+++ b/s3/online-poetry-and-prose/liasoncoordinator.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/lower-case.html
+++ b/s3/online-poetry-and-prose/lower-case.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/poem-being-a-human-being.html
+++ b/s3/online-poetry-and-prose/poem-being-a-human-being.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/online-poetry-and-prose/the-elect.html
+++ b/s3/online-poetry-and-prose/the-elect.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/places-of-the-mind-revised.html
+++ b/s3/places-of-the-mind-revised.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters.html
+++ b/s3/selected-letters.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -30,11 +25,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -58,8 +48,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/sel-letters-re-referendum-2012-2015.html
+++ b/s3/selected-letters/sel-letters-re-referendum-2012-2015.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1988-1989.html
+++ b/s3/selected-letters/selected-letters-1988-1989.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1990.html
+++ b/s3/selected-letters/selected-letters-1990.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1991-1992.html
+++ b/s3/selected-letters/selected-letters-1991-1992.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1994.html
+++ b/s3/selected-letters/selected-letters-1994.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1995.html
+++ b/s3/selected-letters/selected-letters-1995.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1996.html
+++ b/s3/selected-letters/selected-letters-1996.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1997.html
+++ b/s3/selected-letters/selected-letters-1997.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1998.html
+++ b/s3/selected-letters/selected-letters-1998.html
@@ -6,12 +6,7 @@
 <!-- Mirrored from tomleonard.co.uk/selected-letters/selected-letters-1998.html by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 29 Jan 2019 22:58:48 GMT -->
 <!-- Added by HTTrack --><meta http-equiv="content-type" content="text/html;charset=utf-8" /><!-- /Added by HTTrack -->
 <head>
-    <script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
-
+    
 <base  />
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="keywords" content="Tom Leonard, tom leonard, Tom, Leonard, poet, poetry, poems, Scottish Literature, prose, GCSE, literary, Places of the Mind, Intimate Voices, intimate voices, outside the narrative, politics, language, Glasgow, Scottish, Scots, writer, literature," />
@@ -22,12 +17,7 @@ var isRTL = false;
 	<link href="../index900f.css?jat3action=gzip&amp;jat3type=css&amp;jat3file=t3-assets%2Fcss_7e31f.css" rel="stylesheet" type="text/css" />
 	<script type="application/json" class="joomla-script-options new">{"csrf.token":"ae95e06b0905e8174054c78e9c94f70c","system.paths":{"root":"","base":""},"system.keepalive":{"interval":840000,"uri":"\/component\/ajax\/?format=json"}}</script>
 	<script src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js" type="text/javascript"></script>
-	<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
-
+	
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]--> 
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
 <!--[if ie 7]><link href="/templates/ja_purity_ii/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]--> 
@@ -48,7 +38,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript" src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-1999-2005.html
+++ b/s3/selected-letters/selected-letters-1999-2005.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-2006-2010.html
+++ b/s3/selected-letters/selected-letters-2006-2010.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/selected-letters/selected-letters-2011-2015.html
+++ b/s3/selected-letters/selected-letters-2011-2015.html
@@ -8,11 +8,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='../index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="../index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/songs-by-bertolt-brecht.html
+++ b/s3/songs-by-bertolt-brecht.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -31,11 +26,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -59,8 +49,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/videos-slide-poems.html
+++ b/s3/videos-slide-poems.html
@@ -3,11 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb">
 
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -26,11 +21,6 @@ var isRTL = false;
 <script
 	src="index1eae.php?jat3action=gzip&amp;jat3type=js&amp;jat3file=t3-assets%2Fjs_062b6.js"
 	type="text/javascript"></script>
-<script type="text/javascript">
-jQuery(window).on('load',  function() {
-				new JCaption('img.caption');
-			});
-	</script>
 
 <!--[if ie]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie.css" type="text/css" rel="stylesheet" /><![endif]-->
 <!--[if ie 7]><link href="/plugins/system/jat3/jat3/base-themes/default/css/template-ie7.css" type="text/css" rel="stylesheet" /><![endif]-->
@@ -54,8 +44,6 @@ jQuery(window).on('load',  function() {
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {

--- a/s3/web-links.html
+++ b/s3/web-links.html
@@ -7,11 +7,6 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <!-- /Added by HTTrack -->
 <head>
-<script type="text/javascript">
-var siteurl='index.html';
-var tmplurl='http://tomleonard.co.uk/templates/ja_purity_ii/';
-var isRTL = false;
-</script>
 
 <base />
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -56,8 +51,6 @@ var isRTL = false;
 var rightCollapseDefault='show';
 var excludeModules='38';
 </script>
-<script language="javascript" type="text/javascript"
-	src="http://tomleonard.co.uk/templates/ja_purity_ii/js/ja.rightcol.js"></script>
 
 <style type="text/css">
 #ja-header .main {


### PR DESCRIPTION
## Summary
- drop unused `siteurl`/`tmplurl` script blocks from s3 pages
- remove jQuery caption snippet and `ja.rightcol.js` include

## Testing
- `python - <<'PY' from bs4 import BeautifulSoup; import pathlib; [print(p,'navigation links:',len(BeautifulSoup(pathlib.Path(p).read_text(),'html.parser').find('div',{'id':'ja-mainnav'}).find_all('a'))) for p in ['s3/index.html','s3/journal.html','s3/selected-letters.html']] PY`
- `python -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/s3/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689ae98635a8832790852237128ec1c4