### PR TITLE
Fix missing dark/light theme support

### DIFF
--- a/s3/index4b0c.css
+++ b/s3/index4b0c.css
@@ -40,3 +40,27 @@
 /* 615.mega.css */
   .ja-megamenu{margin:0;padding:0;}.ja-megamenu a.over,.ja-megamenu a.active{color:#ffffff !important;}ul.megamenu{margin:10px;}.ja-megamenu ul.level0{border-right:1px solid #666666;float:left;margin:0;padding:0;}.ja-megamenu ul.level0 li.mega{background:none;display:block;float:left;margin:0;padding:0;}.ja-megamenu ul.level0 li.mega a.mega{border-left:1px solid #666666;border-right:1px solid #333333;color:#cccccc;display:block;font-weight:bold;line-height:normal;margin:0;padding:8px 15px;text-decoration:none;}.ja-megamenu ul.level0 li.mega .has-image{padding-left:25px;display:block;background-repeat:no-repeat;background-position:left top;}.ja-megamenu ul.level0 li.mega span.menu-title{display:block;}.ja-megamenu ul.level0 li.mega span.menu-desc{display:block;font-weight:normal;font-size:92%;color:#999;}.ja-megamenu ul.level0 li.mega a img{float:left;padding-right:5px;}.ja-megamenu ul.level0 li.mega.over,.ja-megamenu ul.level0 li.mega.haschild-over{background:url('templates/ja_purity_ii/images/grad1-mask.png') repeat-x center top #666;}ul.level0 li.haschild a.mega span.menu-title,ul.level0 li.haschild-over a.mega span.menu-title{background:url('templates/ja_purity_ii/images/arrow3.png') no-repeat left center;padding-left:12px;}ul.level0 li.haschild a.mega span.menu-desc,ul.level0 li.haschild-over a.mega span.menu-desc{padding-left:12px;}.ja-megamenu ul.level0 li.active.active{background:url('templates/ja_purity_ii/images/grad1-mask.png') repeat-x top #006699;}.ja-megamenu ul.level1 li.mega{border-top:1px dotted #444444;float:none;}.ja-megamenu ul.level1 li.mega.first{border-top:0;}.ja-megamenu ul.level1 li.mega.over,.ja-megamenu ul.level1 li.mega.haschild-over{background:#444;}.ja-megamenu ul.level1.haschild a.mega span.menu-title,.ja-megamenu ul.level1.haschild-over a.mega span.menu-title{background:none;padding-left:0px;}ul.level0 li.haschild a.mega span.menu-desc,ul.level0 li.haschild-over a.mega span.menu-desc{padding-left:12px;}.ja-megamenu ul.level1 li.mega a.mega{background:none;border:0;color:#cccccc;font-weight:normal;padding:5px;}.ja-megamenu ul.level1 li.mega a.mega span.menu-title{background:none;padding:0;}.ja-megamenu ul.level1 li.mega.haschild{background:url('templates/ja_purity_ii/images/arrow.png') no-repeat 95% center;padding:0;}.ja-megamenu ul.level1 li.mega.over,.ja-megamenu ul.level1 li.mega.haschild-over{background:#444444;}ul.level1 li.group{background:none;}.childcontent{z-index:999;}.ja-megamenu .childcontent-inner{background:#333333;border:1px solid #666666;color:#ccc;}.childcontent .ja-moduletable{color:#ccc;border-bottom:0;line-height:1.5;margin:10px 0;padding:0;}.childcontent .ja-moduletable h3{background:none;color:#fff;border-bottom:1px dotted #444;margin-left:10px;margin-right:10px;text-indent:5px;text-transform:none;}.childcontent .ja-moduletable .ja-box-ct{padding:0 5px;}.childcontent .ja-moduletable a{color:#ccc;text-decoration:none;border-bottom:1px dotted #ccc;}.childcontent .ja-moduletable a:hover,.childcontent .ja-moduletable a:focus,.childcontent .ja-moduletable a:active{color:#fff;text-decoration:none;border-bottom:1px solid #fff;}.childcontent .ja-moduletable ul:first-child{margin-top:0 !important;}.childcontent .ja-moduletable li{background:url('templates/ja_purity_ii/images/bullet2.gif') no-repeat 2px 7px !important;margin-bottom:5px;}.group-title{border-bottom:1px solid #444;overflow:hidden;}.group-title .menu-title{color:#fff;text-transform:uppercase;font-weight:bold;font-size:115%;}.group-title .menu-desc{color:#999;padding-left:0 !important;}.group-content .ja-moduletable,.group-content ul.megamenu{margin:10px;}.childcontent ul.megamenu .ja-moduletable{padding:0;}.childcontent ul.megamenu .ja-moduletable h3{margin-left:0;margin-right:0;}
 
+/* Theme support */
+:root {
+  color-scheme: light dark;
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #000000;
+    --text-color: #ffffff;
+  }
+}
+[data-theme='light'] {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+[data-theme='dark'] {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+}
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}

--- a/s3/index900f.css
+++ b/s3/index900f.css
@@ -43,3 +43,27 @@
 /* 615.mega.css */
   .ja-megamenu{margin:0;padding:0;}.ja-megamenu a.over,.ja-megamenu a.active{color:#ffffff !important;}ul.megamenu{margin:10px;}.ja-megamenu ul.level0{border-right:1px solid #666666;float:left;margin:0;padding:0;}.ja-megamenu ul.level0 li.mega{background:none;display:block;float:left;margin:0;padding:0;}.ja-megamenu ul.level0 li.mega a.mega{border-left:1px solid #666666;border-right:1px solid #333333;color:#cccccc;display:block;font-weight:bold;line-height:normal;margin:0;padding:8px 15px;text-decoration:none;}.ja-megamenu ul.level0 li.mega .has-image{padding-left:25px;display:block;background-repeat:no-repeat;background-position:left top;}.ja-megamenu ul.level0 li.mega span.menu-title{display:block;}.ja-megamenu ul.level0 li.mega span.menu-desc{display:block;font-weight:normal;font-size:92%;color:#999;}.ja-megamenu ul.level0 li.mega a img{float:left;padding-right:5px;}.ja-megamenu ul.level0 li.mega.over,.ja-megamenu ul.level0 li.mega.haschild-over{background:url('templates/ja_purity_ii/images/grad1-mask.png') repeat-x center top #666;}ul.level0 li.haschild a.mega span.menu-title,ul.level0 li.haschild-over a.mega span.menu-title{background:url('templates/ja_purity_ii/images/arrow3.png') no-repeat left center;padding-left:12px;}ul.level0 li.haschild a.mega span.menu-desc,ul.level0 li.haschild-over a.mega span.menu-desc{padding-left:12px;}.ja-megamenu ul.level0 li.active.active{background:url('templates/ja_purity_ii/images/grad1-mask.png') repeat-x top #006699;}.ja-megamenu ul.level1 li.mega{border-top:1px dotted #444444;float:none;}.ja-megamenu ul.level1 li.mega.first{border-top:0;}.ja-megamenu ul.level1 li.mega.over,.ja-megamenu ul.level1 li.mega.haschild-over{background:#444;}.ja-megamenu ul.level1.haschild a.mega span.menu-title,.ja-megamenu ul.level1.haschild-over a.mega span.menu-title{background:none;padding-left:0px;}ul.level0 li.haschild a.mega span.menu-desc,ul.level0 li.haschild-over a.mega span.menu-desc{padding-left:12px;}.ja-megamenu ul.level1 li.mega a.mega{background:none;border:0;color:#cccccc;font-weight:normal;padding:5px;}.ja-megamenu ul.level1 li.mega a.mega span.menu-title{background:none;padding:0;}.ja-megamenu ul.level1 li.mega.haschild{background:url('templates/ja_purity_ii/images/arrow.png') no-repeat 95% center;padding:0;}.ja-megamenu ul.level1 li.mega.over,.ja-megamenu ul.level1 li.mega.haschild-over{background:#444444;}ul.level1 li.group{background:none;}.childcontent{z-index:999;}.ja-megamenu .childcontent-inner{background:#333333;border:1px solid #666666;color:#ccc;}.childcontent .ja-moduletable{color:#ccc;border-bottom:0;line-height:1.5;margin:10px 0;padding:0;}.childcontent .ja-moduletable h3{background:none;color:#fff;border-bottom:1px dotted #444;margin-left:10px;margin-right:10px;text-indent:5px;text-transform:none;}.childcontent .ja-moduletable .ja-box-ct{padding:0 5px;}.childcontent .ja-moduletable a{color:#ccc;text-decoration:none;border-bottom:1px dotted #ccc;}.childcontent .ja-moduletable a:hover,.childcontent .ja-moduletable a:focus,.childcontent .ja-moduletable a:active{color:#fff;text-decoration:none;border-bottom:1px solid #fff;}.childcontent .ja-moduletable ul:first-child{margin-top:0 !important;}.childcontent .ja-moduletable li{background:url('templates/ja_purity_ii/images/bullet2.gif') no-repeat 2px 7px !important;margin-bottom:5px;}.group-title{border-bottom:1px solid #444;overflow:hidden;}.group-title .menu-title{color:#fff;text-transform:uppercase;font-weight:bold;font-size:115%;}.group-title .menu-desc{color:#999;padding-left:0 !important;}.group-content .ja-moduletable,.group-content ul.megamenu{margin:10px;}.childcontent ul.megamenu .ja-moduletable{padding:0;}.childcontent ul.megamenu .ja-moduletable h3{margin-left:0;margin-right:0;}
 
+/* Theme support */
+:root {
+  color-scheme: light dark;
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #000000;
+    --text-color: #ffffff;
+  }
+}
+[data-theme='light'] {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+}
+[data-theme='dark'] {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+}
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}


### PR DESCRIPTION
## Summary
- restore dark/light/system theme styling via CSS variables and `prefers-color-scheme`

## Testing
- `bash run-dev.sh` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c98518afc83279c8ebb4a597277f5