### PR TITLE
Gracefully handle missing npm in run-dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+__pycache__/
+*.pyc

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -7,6 +7,12 @@ if [ ! -f package.json ]; then
   exit 1
 fi
 
+# Ensure npm is installed
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is not installed. Please install Node.js and npm." >&2
+  exit 1
+fi
+
 # First install packages already listed in package.json
 npm install
 

--- a/tests/test_run_dev_sh.py
+++ b/tests/test_run_dev_sh.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_dev_requires_npm(tmp_path):
+    # Create dummy package.json so the script progresses to npm check
+    (tmp_path / 'package.json').write_text('{}')
+    script = Path(__file__).resolve().parent.parent / 'run-dev.sh'
+    env = os.environ.copy()
+    env['PATH'] = '/nonexistent'
+    result = subprocess.run(['/bin/bash', str(script)], cwd=tmp_path, capture_output=True, text=True, env=env)
+    assert result.returncode != 0
+    assert 'npm is not installed' in result.stderr


### PR DESCRIPTION
## Summary
- add npm presence check to run-dev.sh before installing dependencies
- ignore Python bytecode files in version control
- test that run-dev.sh reports a helpful error when npm is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdc060fcc8327b1857e639484c0c6